### PR TITLE
Remove obsolete fields

### DIFF
--- a/exreport/test.go
+++ b/exreport/test.go
@@ -2,9 +2,7 @@ package exreport
 
 // Test represents the result of a test
 type Test struct {
-	Name     string `json:"name"`
-	Status   string `json:"status"`
-	Expected string `json:"expected"`
-	Actual   string `json:"actual"`
-	Message  string `json:"message"`
+	Name    string `json:"name"`
+	Status  string `json:"status"`
+	Message string `json:"message"`
 }


### PR DESCRIPTION
The `expected` and `actual` fields are no longer part of the [test interface](https://github.com/exercism/automated-tests/blob/master/docs/interface.md).