### PR TITLE
Configure the env-vars that docker implicitly sets

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -14,7 +14,6 @@
 
 # The docker container will compile our "testoutput" module as "test-runner"
 
-export GOLANG_VERSION=1.13.5
 export GOPATH=/go
 export PATH="$GOPATH/bin:/usr/local/go/bin:$PATH"
 

--- a/run.sh
+++ b/run.sh
@@ -14,6 +14,10 @@
 
 # The docker container will compile our "testoutput" module as "test-runner"
 
+export GOLANG_VERSION=1.13.5
+export GOPATH=/go
+export PATH="$GOPATH/bin:/usr/local/go/bin:$PATH"
+
 cd "$2" || exit
 go test --json . | /opt/test-runner/test-runner > $3/results.json
 


### PR DESCRIPTION
Please feel free to implement this another way, but I need a number of env-vars setting in the run.sh script.

Although we're building the container images from Dockerfiles, we're not invoking them through Docker (instead we're exporting them as OCI containers and invoking with `runc`). As a result, the implicit runtime config that gets set via the Dockerfile chain is missing from our invocation environment,

Specifically, we need the ENV directives from the base image's Dockerfile, see https://github.com/docker-library/golang/blob/73558b65009ae95e19cc94c2b1baff381a577371/1.13/alpine3.11/Dockerfile

I've added three env-vars to the run.sh script, the one that worries me the most is the GOLANG_VERSION one, having an explicit version here feels brittle. I've done some experiments and it seems OK to omit the the GOLANG_VERSION so unless it rings alarm bells, you could just keep one that mutates the PATH.

Thanks,

Charles
