### PR TITLE
Test Runner Updated to Meet Spec and Improve Error Handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The test runner requires 2 parameters:
 ### Local Development
 
 ```bash
-go run . ~/Exercism/go/gigasecond outdir
+go run . ./testdata/practice/passing outdir
 ```
 
 ### Docker

--- a/extract.go
+++ b/extract.go
@@ -53,9 +53,16 @@ func extractTestCode(testName string, testFile string) string {
 	if 0 == len(subtest) {
 		return tc
 	}
+	defer handleASTPanic()
 	subtc := getSubCode(test, subtest, tc, testFile)
 	if 0 == len(subtc) {
 		return tc
 	}
 	return subtc
+}
+
+func handleASTPanic() {
+	if r := recover(); r != nil {
+		fmt.Println("warning: AST parsing failed to extract test code: ", r)
+	}
 }

--- a/extract_test.go
+++ b/extract_test.go
@@ -147,7 +147,7 @@ func TestExtractTestCode(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// whitespace / tabs were difficult to match between the test files
-			// and the test code / strings... so strip it
+			// and the test code / strings... so strip them
 			code := extractTestCode(tt.testName, tt.testFile)
 			code = strings.Join(strings.Fields(code), " ")
 			ttcode := strings.Join(strings.Fields(tt.code), " ")

--- a/main.go
+++ b/main.go
@@ -201,28 +201,33 @@ func runTests(input_dir string) (bytes.Buffer, bool) {
 		Stderr: &stderr,
 	}
 
-	// Test ran without any problems, return json
-	if err := testCmd.Run(); err == nil {
+	err = testCmd.Run()
+	if err == nil {
+		// Test ran without any problems, return json
 		return stdout, true
-	} else if exitError, ok := err.(*exec.ExitError); !ok {
+	}
+
+	exitError, ok := err.(*exec.ExitError)
+	if !ok {
 		log.Fatalf("error: '%s' failed with non exit error %s",
 			testCmd.String(), err,
 		)
-		switch exc := exitError.ExitCode(); exc {
-		case 1:
-			// `go test` returns 1 when tests fail, this is fine
-			return stdout, true
-		case 2:
-			//  go test returns 2 on a compilation / build error
-			stdout.WriteString(fmt.Sprintf("'%s' returned exit code %d: %s",
-				testCmd.String(), exc, err,
-			))
-			return stdout, false
-		default:
-			log.Fatalf("error: '%s' failed with exit error %d: %s",
-				testCmd.String(), exc, err,
-			)
-		}
+	}
+
+	switch exc := exitError.ExitCode(); exc {
+	case 1:
+		// `go test` returns 1 when tests fail, this is fine
+		return stdout, true
+	case 2:
+		//  go test returns 2 on a compilation / build error
+		stdout.WriteString(fmt.Sprintf("'%s' returned exit code %d: %s",
+			testCmd.String(), exc, err,
+		))
+		return stdout, false
+	default:
+		log.Fatalf("error: '%s' failed with exit error %d: %s",
+			testCmd.String(), exc, err,
+		)
 	}
 	return stdout, false
 }

--- a/main.go
+++ b/main.go
@@ -76,13 +76,13 @@ func main() {
 
 	bts, err := json.MarshalIndent(output, "", "\t")
 	if err != nil {
-		log.Fatalf("error: Failed to marshal json from `go test` output: %s", err)
+		log.Fatalf("Failed to marshal json from `go test` output: %s", err)
 	}
 
 	results := filepath.Join(output_dir, "results.json")
 	err = ioutil.WriteFile(results, bts, 0644)
 	if err != nil {
-		log.Fatalf("error: Failed to write results.json: %s", err)
+		log.Fatalf("Failed to write results.json: %s", err)
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,14 +1,93 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 )
 
-func ExampleBrokenTest() {
-	if cmdres, ok := runTests("./testdata/practice/broken"); ok {
+func ExampleBrokenTestRun() {
+	input_dir := "./testdata/practice/broken"
+	if cmdres, ok := runTests(input_dir); ok {
 		fmt.Printf("Broken test did not fail %s", cmdres.String())
 	} else {
 		fmt.Println(cmdres.String())
 	}
 	// Output: FAIL	github.com/exercism/go-test-runner/testdata/practice/broken [build failed]
+	//'/usr/local/bin/go test --json .' returned exit code 2: exit status 2
+}
+
+func ExampleBrokenTestJson() {
+	input_dir := "./testdata/practice/broken"
+	cmdres, ok := runTests(input_dir)
+	if ok {
+		fmt.Printf("Broken test did not fail: %s", cmdres.String())
+	}
+	output := &testReport{
+		Status:  statErr,
+		Message: cmdres.String(),
+	}
+	if bts, err := json.MarshalIndent(output, "", "\t"); err != nil {
+		fmt.Printf("Broken test output not valid json: %s", err)
+	} else {
+		fmt.Println(string(bts))
+	}
+	// Output: {
+	//	"status": "error",
+	//	"message": "FAIL\tgithub.com/exercism/go-test-runner/testdata/practice/broken [build failed]\n'/usr/local/bin/go test --json .' returned exit code 2: exit status 2",
+	//	"tests": null
+	//}
+}
+
+func ExamplePassingTestJson() {
+	input_dir := "./testdata/practice/passing"
+
+	cmdres, ok := runTests(input_dir)
+	if !ok {
+		fmt.Printf("Passing test failed: %s", cmdres.String())
+	}
+
+	output := getStructure(cmdres, input_dir)
+	if bts, err := json.MarshalIndent(output, "", "\t"); err != nil {
+		fmt.Printf("Passing test output not valid json: %s", err)
+	} else {
+		fmt.Println(string(bts))
+	}
+	// Output: {
+	//	"status": "pass",
+	//	"tests": [
+	//		{
+	//			"name": "TestTrivialPass",
+	//			"status": "pass",
+	//			"test_code": "// Trivial passing test example\nfunc TestTrivialPass(t *testing.T) {\n\tif true != true {\n\t\tt.Fatal(\"This was supposed to be a tautological statement!\")\n\t}\n\tfmt.Println(\"sample passing test output\")\n}",
+	//			"message": "\n=== RUN   TestTrivialPass\n\nsample passing test output\n\n--- PASS: TestTrivialPass (0.00s)\n"
+	//		}
+	//	]
+	//}
+}
+
+func ExampleFailingTestJson() {
+	input_dir := "./testdata/practice/failing"
+
+	cmdres, ok := runTests(input_dir)
+	if !ok {
+		fmt.Printf("Failing test expected to return ok: %s", cmdres.String())
+	}
+
+	output := getStructure(cmdres, input_dir)
+	if bts, err := json.MarshalIndent(output, "", "\t"); err != nil {
+		fmt.Printf("Failing test output not valid json: %s", err)
+	} else {
+		fmt.Println(string(bts))
+	}
+	// Output: {
+	//	"status": "fail",
+	//	"tests": [
+	//		{
+	//			"name": "TestTrivialFail",
+	//			"status": "fail",
+	//			"test_code": "// Trivial failing test example\nfunc TestTrivialFail(t *testing.T) {\n\tif false != true {\n\t\tt.Fatal(\"Intentional test failure\")\n\t}\n\tfmt.Println(\"sample failing test output\")\n}",
+	//			"message": "\n=== RUN   TestTrivialFail\n\n    failing_test.go:11: Intentional test failure\n\n--- FAIL: TestTrivialFail (0.00s)\n"
+	//		}
+	//	]
+	//}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"fmt"
+)
+
+func ExampleBrokenTest() {
+	if cmdres, ok := runTests("./testdata/practice/broken"); ok {
+		fmt.Printf("Broken test did not fail %s", cmdres.String())
+	} else {
+		fmt.Println(cmdres.String())
+	}
+	// Output: FAIL	github.com/exercism/go-test-runner/testdata/practice/broken [build failed]
+}

--- a/testdata/concept/conditionals/conditionals_test.go
+++ b/testdata/concept/conditionals/conditionals_test.go
@@ -25,7 +25,7 @@ func TestTODOSubtest(t *testing.T) {
 	}
 	// A stmt between the test data and the range will prevent subtest processing
 	// [TODO] - fix this, along with the TestBlackjack test below
-	anything := "literally anything"
+	_ = "literally anything"
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := ParseCard(tt.card); got != tt.want {

--- a/testdata/practice/broken/broken.go
+++ b/testdata/practice/broken/broken.go
@@ -1,7 +1,6 @@
 // https://exercism.io/tracks/go/exercises/gigasecond
 package gigasecond
 
-// import path for the time package from the standard library
 import "time"
 
 const Gigasecond = time.Second * 1e9

--- a/testdata/practice/broken/broken.go
+++ b/testdata/practice/broken/broken.go
@@ -1,0 +1,13 @@
+// https://exercism.io/tracks/go/exercises/gigasecond
+package gigasecond
+
+// import path for the time package from the standard library
+import "time"
+
+const Gigasecond = time.Second * 1e9
+
+// Add a Gigasecond (10^9) to the input time
+func AddGigasecond(t time.Time) time.Time {
+	hmm = nil
+	return t.Add(Gigasecond)
+}

--- a/testdata/practice/broken/broken_test.go
+++ b/testdata/practice/broken/broken_test.go
@@ -1,0 +1,78 @@
+package gigasecond
+
+import (
+	"testing"
+	"time"
+)
+
+// date formats used in test data
+const (
+	fmtD  = "2006-01-02"
+	fmtDt = "2006-01-02T15:04:05"
+)
+
+// Write a function AddGigasecond that works with a date
+func TestAddGigasecondDate(t *testing.T) {
+	var addCases = []struct {
+		description string
+		in          string
+		want        string
+	}{
+		{
+			"date only specification of time",
+			"2011-04-25",
+			"2043-01-01T01:46:40",
+		}, {
+			"second test for date only specification of time",
+			"1977-06-13",
+			"2009-02-19T01:46:40",
+		}, {
+			"third test for date only specification of time",
+			"1959-07-19",
+			"1991-03-27T01:46:40",
+		},
+	}
+	for _, tc := range addCases {
+		t.Run(tc.description, func(t *testing.T) {
+			in, _ := time.Parse(fmtD, tc.in)
+			want, _ := time.Parse(fmtDt, tc.want)
+			got := AddGigasecond(in)
+			if !got.Equal(want) {
+				t.Fatalf(`FAIL: %s AddGigasecond(%s) = %s want %s`,
+					tc.description, in, got, want,
+				)
+			}
+		})
+	}
+
+}
+
+// Write a function AddGigasecond that works with a date + time
+func TestAddGigasecondFullTime(t *testing.T) {
+	var addCases = []struct {
+		description string
+		in          string
+		want        string
+	}{
+		{
+			"full time specified",
+			"2015-01-24T22:00:00",
+			"2046-10-02T23:46:40",
+		},
+		{
+			"full time with day roll-over",
+			"2015-01-24T23:59:59",
+			"2046-10-03T01:46:39",
+		},
+	}
+	for _, tc := range addCases {
+		t.Run(tc.description, func(t *testing.T) {
+			in, _ := time.Parse(fmtDt, tc.in)
+			want, _ := time.Parse(fmtDt, tc.want)
+			got := AddGigasecond(in)
+			if !got.Equal(want) {
+				t.Fatalf(`AddGigasecond(%s) = %s want %s`, in, got, want)
+			}
+		})
+	}
+}

--- a/testdata/practice/failing/failing.go
+++ b/testdata/practice/failing/failing.go
@@ -1,7 +1,6 @@
 // https://exercism.io/tracks/go/exercises/gigasecond
 package gigasecond
 
-// import path for the time package from the standard library
 import "time"
 
 const Gigasecond = time.Second * 1e9

--- a/testdata/practice/failing/failing.go
+++ b/testdata/practice/failing/failing.go
@@ -8,7 +8,5 @@ const Gigasecond = time.Second * 1e9
 
 // Add a Gigasecond (10^9) to the input time
 func AddGigasecond(t time.Time) time.Time {
-	// intentional compilation error
-	hmm = nil
 	return t.Add(Gigasecond)
 }

--- a/testdata/practice/failing/failing_test.go
+++ b/testdata/practice/failing/failing_test.go
@@ -1,0 +1,14 @@
+package gigasecond
+
+import (
+	"fmt"
+	"testing"
+)
+
+// Trivial failing test example
+func TestTrivialFail(t *testing.T) {
+	if false != true {
+		t.Fatal("Intentional test failure")
+	}
+	fmt.Println("sample failing test output")
+}

--- a/testdata/practice/gigasecond/gigasecond.go
+++ b/testdata/practice/gigasecond/gigasecond.go
@@ -1,7 +1,6 @@
 // https://exercism.io/tracks/go/exercises/gigasecond
 package gigasecond
 
-// import path for the time package from the standard library
 import "time"
 
 const Gigasecond = time.Second * 1e9

--- a/testdata/practice/gigasecond/gigasecond.go
+++ b/testdata/practice/gigasecond/gigasecond.go
@@ -1,0 +1,12 @@
+// https://exercism.io/tracks/go/exercises/gigasecond
+package gigasecond
+
+// import path for the time package from the standard library
+import "time"
+
+const Gigasecond = time.Second * 1e9
+
+// Add a Gigasecond (10^9) to the input time
+func AddGigasecond(t time.Time) time.Time {
+	return t.Add(Gigasecond)
+}

--- a/testdata/practice/gigasecond/gigasecond_test.go
+++ b/testdata/practice/gigasecond/gigasecond_test.go
@@ -1,0 +1,78 @@
+package gigasecond
+
+import (
+	"testing"
+	"time"
+)
+
+// date formats used in test data
+const (
+	fmtD  = "2006-01-02"
+	fmtDt = "2006-01-02T15:04:05"
+)
+
+// Write a function AddGigasecond that works with a date
+func TestAddGigasecondDate(t *testing.T) {
+	var addCases = []struct {
+		description string
+		in          string
+		want        string
+	}{
+		{
+			"date only specification of time",
+			"2011-04-25",
+			"2043-01-01T01:46:40",
+		}, {
+			"second test for date only specification of time",
+			"1977-06-13",
+			"2009-02-19T01:46:40",
+		}, {
+			"third test for date only specification of time",
+			"1959-07-19",
+			"1991-03-27T01:46:40",
+		},
+	}
+	for _, tc := range addCases {
+		t.Run(tc.description, func(t *testing.T) {
+			in, _ := time.Parse(fmtD, tc.in)
+			want, _ := time.Parse(fmtDt, tc.want)
+			got := AddGigasecond(in)
+			if !got.Equal(want) {
+				t.Fatalf(`FAIL: %s AddGigasecond(%s) = %s want %s`,
+					tc.description, in, got, want,
+				)
+			}
+		})
+	}
+
+}
+
+// Write a function AddGigasecond that works with a date + time
+func TestAddGigasecondFullTime(t *testing.T) {
+	var addCases = []struct {
+		description string
+		in          string
+		want        string
+	}{
+		{
+			"full time specified",
+			"2015-01-24T22:00:00",
+			"2046-10-02T23:46:40",
+		},
+		{
+			"full time with day roll-over",
+			"2015-01-24T23:59:59",
+			"2046-10-03T01:46:39",
+		},
+	}
+	for _, tc := range addCases {
+		t.Run(tc.description, func(t *testing.T) {
+			in, _ := time.Parse(fmtDt, tc.in)
+			want, _ := time.Parse(fmtDt, tc.want)
+			got := AddGigasecond(in)
+			if !got.Equal(want) {
+				t.Fatalf(`AddGigasecond(%s) = %s want %s`, in, got, want)
+			}
+		})
+	}
+}

--- a/testdata/practice/passing/passing.go
+++ b/testdata/practice/passing/passing.go
@@ -1,7 +1,6 @@
 // https://exercism.io/tracks/go/exercises/gigasecond
 package gigasecond
 
-// import path for the time package from the standard library
 import "time"
 
 const Gigasecond = time.Second * 1e9

--- a/testdata/practice/passing/passing.go
+++ b/testdata/practice/passing/passing.go
@@ -8,7 +8,5 @@ const Gigasecond = time.Second * 1e9
 
 // Add a Gigasecond (10^9) to the input time
 func AddGigasecond(t time.Time) time.Time {
-	// intentional compilation error
-	hmm = nil
 	return t.Add(Gigasecond)
 }

--- a/testdata/practice/passing/passing_test.go
+++ b/testdata/practice/passing/passing_test.go
@@ -1,0 +1,14 @@
+package gigasecond
+
+import (
+	"fmt"
+	"testing"
+)
+
+// Trivial passing test example
+func TestTrivialPass(t *testing.T) {
+	if true != true {
+		t.Fatal("This was supposed to be a tautological statement!")
+	}
+	fmt.Println("sample passing test output")
+}


### PR DESCRIPTION
This PR should resolve the open issues rolled over from #19 and #17. I would like to add the github actions for the test run in a separate PR, but I'm fine with holding this one open for that.

@ErikSchierboom, [regarding this comment in PR 17](https://github.com/exercism/go-test-runner/pull/17#discussion_r538106538), I'm not seeing [anywhere in the spec](https://github.com/exercism/v3-docs/blob/master/anatomy/track-tooling/test-runners/interface.md) which requires the slug to be output. We do accept the parameter in the shell script / docker execution, but given it is not used, the Go command doesn't accept it as input. Is this OK, or am I missing a requirement somewhere? 

Lastly, do we want to address #8? 
