### PR TITLE
Update to Go 1.17

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,18 +10,18 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15.x
+        go-version: 1.17.x
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Run linters
       uses: golangci/golangci-lint-action@v2
       with:
-        version: v1.29
+        version: v1.43
 
   test:
     strategy:
       matrix:
-        go-version: [1.15.x]
+        go-version: [1.17.x]
         # platform: [ubuntu-latest, macos-latest, windows-latest]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
@@ -43,7 +43,7 @@ jobs:
       if: success()
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15.x
+        go-version: 1.17.x
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Calc coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15-buster
+FROM golang:1.17-alpine3.14
 
 # add a non-root user to run our code as
 RUN adduser --disabled-password --gecos "" appuser

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/exercism/go-test-runner
 
-go 1.15
+go 1.17

--- a/testrunner/testdata/concept/conditionals/go.mod
+++ b/testrunner/testdata/concept/conditionals/go.mod
@@ -1,5 +1,3 @@
 module conditionals
 
-go 1.13
-
-require github.com/exercism/go-test-runner v0.0.0-20201110071058-ea853a2fccba // indirect
+go 1.17

--- a/testrunner/testdata/practice/broken/go.mod
+++ b/testrunner/testdata/practice/broken/go.mod
@@ -1,0 +1,3 @@
+module gigasecond
+
+go 1.17

--- a/testrunner/testdata/practice/broken_import/go.mod
+++ b/testrunner/testdata/practice/broken_import/go.mod
@@ -1,0 +1,3 @@
+module gigasecond
+
+go 1.17

--- a/testrunner/testdata/practice/failing/go.mod
+++ b/testrunner/testdata/practice/failing/go.mod
@@ -1,0 +1,3 @@
+module gigasecond
+
+go 1.17

--- a/testrunner/testdata/practice/gigasecond/go.mod
+++ b/testrunner/testdata/practice/gigasecond/go.mod
@@ -1,0 +1,3 @@
+module gigasecond
+
+go 1.17

--- a/testrunner/testdata/practice/missing_func/go.mod
+++ b/testrunner/testdata/practice/missing_func/go.mod
@@ -1,0 +1,3 @@
+module gigasecond
+
+go 1.17

--- a/testrunner/testdata/practice/passing/go.mod
+++ b/testrunner/testdata/practice/passing/go.mod
@@ -1,0 +1,3 @@
+module gigasecond
+
+go 1.17


### PR DESCRIPTION
Part of https://github.com/exercism/go/issues/1881

On this one I noticed we are using `buster` instead of alpine - is there any historical reason for this?

Related PR's: 
* https://github.com/exercism/go-analyzer/pull/26
* https://github.com/exercism/go-representer/pull/12