### PR TITLE
remove the unnecessary fmt.Scanln command

### DIFF
--- a/testrunner/extract.go
+++ b/testrunner/extract.go
@@ -29,9 +29,7 @@ func findTestFile(testName string, codePath string) string {
 	testdef := fmt.Sprintf("func %s", test)
 	for _, f := range files {
 		if strings.HasSuffix(f.Name(), "_test.go") {
-			var code string
 			testpath := filepath.Join(codePath, f.Name())
-			fmt.Scanln(&code)
 			fh, err := ioutil.ReadFile(testpath)
 			if err != nil {
 				log.Printf("warning: test file '%s' read failed: %s", testpath, err)


### PR DESCRIPTION
Fixes #59  in the way suggested here https://github.com/exercism/go-test-runner/issues/59#issuecomment-999874166

Without this code test runner has been tested following scenarios and it seems perfectly fine.

## 1. Running the test runner on Windows/Linux
```bash
$ go run . testrunner/testdata/practice/passing test
```
## 2. Running the test runner in the container by passing in the slug name
```bash
# Build the local docker image
$ docker build --rm -t exercism/test-runner .

# Run the test runner and see the results in the test folder
$ docker run --network none -v $(pwd)/testrunner/testdata/practice/gigasecond:/solution -v $(pwd)/test:/test exercism/test-runner gigasecond /solution /test
```
## 3. Running the test runner in the container by using attached mode
```bash
# Build the local docker image
$ docker build --rm -t exercism/test-runner .

# Run a container with attachmed mode
$ docker run --entrypoint /bin/sh --rm --name exercism-go-test-runner -d --network none -v $(pwd):/opt/test-runner -v $(pwd)/test:/test -it exercism/test-runner

# Access the container
$ docker exec -it --user appuser $(docker ps -q --filter name=exercism-go-test-runner) /bin/sh

# Run the test runner inside the container
$ go run . testrunner/testdata/practice/passing /test
```
