### PR TITLE
Fix CI test run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Run tests
-      run: go test -v -covermode=count
+      run: go test ./... -v -covermode=count
 
   coverage:
     runs-on: ubuntu-latest
@@ -48,7 +48,7 @@ jobs:
       uses: actions/checkout@v2
     - name: Calc coverage
       run: |
-        go test -v -covermode=count -coverprofile=coverage.out
+        go test ./... -v -covermode=count -coverprofile=coverage.out
     - name: Convert coverage.out to coverage.lcov
       uses: jandelgado/gcov2lcov-action@v1.0.6
     - name: Coveralls

--- a/testrunner/execute_test.go
+++ b/testrunner/execute_test.go
@@ -21,10 +21,10 @@ func TestRunTests_broken(t *testing.T) {
 	lines := strings.Split(res, "\n")
 
 	expectedLineSuffixes := []string{
-		"# github.com/exercism/go-test-runner/testrunner/testdata/practice/broken [github.com/exercism/go-test-runner/testrunner/testdata/practice/broken.test]",
+		"# gigasecond [gigasecond.test]",
 		"broken.go:11:2: undefined: unknownVar",
 		"broken.go:12:2: undefined: UnknownFunction",
-		"FAIL	github.com/exercism/go-test-runner/testrunner/testdata/practice/broken [build failed]",
+		"FAIL	gigasecond [build failed]",
 		"returned exit code 2: exit status 2",
 	}
 
@@ -48,7 +48,7 @@ func TestRunTests_broken(t *testing.T) {
 	pre := `{
 	"status": "error",
 	"version": 2,
-	"message": "# github.com/exercism/go-test-runner/testrunner/testdata/practice/broken`
+	"message": "# gigasecond`
 
 	post := `returned exit code 2: exit status 2",
 	"tests": null
@@ -74,10 +74,10 @@ func TestRunTests_missingFunc(t *testing.T) {
 	lines := strings.Split(res, "\n")
 
 	expectedLineSuffixes := []string{
-		"# github.com/exercism/go-test-runner/testrunner/testdata/practice/missing_func [github.com/exercism/go-test-runner/testrunner/testdata/practice/missing_func.test]",
+		"# gigasecond [gigasecond.test]",
 		"missing_func_test.go:39:11: undefined: AddGigasecond",
 		"missing_func_test.go:72:11: undefined: AddGigasecond",
-		"FAIL	github.com/exercism/go-test-runner/testrunner/testdata/practice/missing_func [build failed]",
+		"FAIL	gigasecond [build failed]",
 		"returned exit code 2: exit status 2",
 	}
 
@@ -101,7 +101,7 @@ func TestRunTests_missingFunc(t *testing.T) {
 	pre := `{
 	"status": "error",
 	"version": 2,
-	"message": "# github.com/exercism/go-test-runner/testrunner/testdata/practice/missing_func`
+	"message": "# gigasecond`
 
 	post := `returned exit code 2: exit status 2",
 	"tests": null


### PR DESCRIPTION
I realized that the CI only runs the tests for main.go but not the tests in ./testrunner. I also found some tests are currently failing. Will try to fix this with this PR.

Update: The tests broke during the update to Go 1.17. The new go.mod files set a module name which then changed the output of the test runs. Since the CI was not set up correctly, we did not notice the failing tests.

To summarize, this PR fixes the CI so all tests are executed and it fixes the previously failing test cases.