### PR TITLE
Avoid that package level errors are ignored

### DIFF
--- a/testrunner/execute.go
+++ b/testrunner/execute.go
@@ -107,6 +107,7 @@ func buildTests(lines bytes.Buffer, input_dir string) ([]testResult, error) {
 		resultIdxByName = make(map[string]int)
 		testFileMap     = make(map[string]string)
 		failMsg         [][]byte
+		pkgLevelMsg     string
 	)
 
 	scanner := bufio.NewScanner(&lines)
@@ -129,6 +130,9 @@ func buildTests(lines bytes.Buffer, input_dir string) ([]testResult, error) {
 		}
 
 		if line.Test == "" {
+			// We collect messages that do not belong to an individual test and use them later
+			// as error message in case there was no test level messsage found at all.
+			pkgLevelMsg += line.Output
 			continue
 		}
 
@@ -183,9 +187,15 @@ func buildTests(lines bytes.Buffer, input_dir string) ([]testResult, error) {
 		}
 
 	}
+
 	if len(failMsg) != 0 {
 		return nil, errors.New(string(bytes.Join(failMsg, []byte{'\n'})))
 	}
+
+	if len(results) == 0 {
+		return nil, errors.New(pkgLevelMsg)
+	}
+
 	return results, nil
 }
 

--- a/testrunner/execute.go
+++ b/testrunner/execute.go
@@ -192,7 +192,7 @@ func buildTests(lines bytes.Buffer, input_dir string) ([]testResult, error) {
 		return nil, errors.New(string(bytes.Join(failMsg, []byte{'\n'})))
 	}
 
-	if len(results) == 0 {
+	if len(results) == 0 && pkgLevelMsg != "" {
 		return nil, errors.New(pkgLevelMsg)
 	}
 

--- a/testrunner/execute_test.go
+++ b/testrunner/execute_test.go
@@ -112,7 +112,7 @@ func TestRunTests_RuntimeError(t *testing.T) {
 			"message": "\n=== RUN   TestAddGigasecond\n\nruntime: goroutine stack exceeds`
 
 	if !strings.HasPrefix(result, pre) {
-		t.Errorf("Broken import test run unexpected json prefix: %s", result)
+		t.Errorf("runtime error result has unexpected json prefix: %s", result)
 	}
 }
 
@@ -137,6 +137,31 @@ func TestRunTests_passing(t *testing.T) {
 
 	if string(jsonBytes) != string(expectedOutput) {
 		t.Errorf("Passing test failed, got:\n%s\n, want:\n%s\n", string(jsonBytes), string(expectedOutput))
+	}
+}
+
+func TestRunTests_PkgLevelError(t *testing.T) {
+	input_dir := "./testdata/practice/pkg_level_error"
+	cmdres, ok := runTests(input_dir)
+	if !ok {
+		fmt.Printf("pkg level error test expected to return ok: %s", cmdres.String())
+	}
+
+	output := getStructure(cmdres, input_dir, version)
+	jsonBytes, err := json.MarshalIndent(output, "", "\t")
+	if err != nil {
+		t.Fatalf("pkg level error output not valid json: %s", err)
+	}
+
+	result := string(jsonBytes)
+
+	pre := `{
+	"status": "error",
+	"version": 2,
+	"message": "panic: Please implement this function`
+
+	if !strings.HasPrefix(result, pre) {
+		t.Errorf("pkg level error result has unexpected json prefix: %s", result)
 	}
 }
 

--- a/testrunner/testdata/practice/pkg_level_error/go.mod
+++ b/testrunner/testdata/practice/pkg_level_error/go.mod
@@ -1,0 +1,4 @@
+module pov
+
+go 1.17
+

--- a/testrunner/testdata/practice/pkg_level_error/helper_test.go
+++ b/testrunner/testdata/practice/pkg_level_error/helper_test.go
@@ -1,0 +1,22 @@
+package pov
+
+// source: problem-specification repo - POV exercise
+
+type TestTreeData struct {
+	root     string
+	children []*Tree
+}
+
+var testTrees = map[string]TestTreeData{
+	"singleton": {
+		root:     "x",
+		children: nil,
+	},
+}
+
+var newValueChildrenTestTrees = []string{"singleton"}
+
+func mkTestTree(treeName string) *Tree {
+	treeData := testTrees[treeName]
+	return New(treeData.root, treeData.children...)
+}

--- a/testrunner/testdata/practice/pkg_level_error/helper_test.go
+++ b/testrunner/testdata/practice/pkg_level_error/helper_test.go
@@ -12,9 +12,17 @@ var testTrees = map[string]TestTreeData{
 		root:     "x",
 		children: nil,
 	},
+	"parent and one sibling": {
+		root:     "parent",
+		children: []*Tree{New("x"), New("sibling")},
+	},
+	"parent and kids": {
+		root:     "parent",
+		children: []*Tree{New("x", New("kid-0"), New("kid-1"))},
+	},
 }
 
-var newValueChildrenTestTrees = []string{"singleton"}
+var newValueChildrenTestTrees = []string{"singleton", "parent and one sibling", "parent and kids"}
 
 func mkTestTree(treeName string) *Tree {
 	treeData := testTrees[treeName]

--- a/testrunner/testdata/practice/pkg_level_error/pkg_level_error.go
+++ b/testrunner/testdata/practice/pkg_level_error/pkg_level_error.go
@@ -1,0 +1,10 @@
+package pov
+
+type Tree struct {
+	// Add the needed fields here
+}
+
+// New creates and returns a new Tree with the given root value and children.
+func New(value string, children ...*Tree) *Tree {
+	panic("Please implement this function")
+}

--- a/testrunner/testdata/practice/pkg_level_error/pkg_level_error_test.go
+++ b/testrunner/testdata/practice/pkg_level_error/pkg_level_error_test.go
@@ -1,0 +1,16 @@
+package pov
+
+import (
+	"testing"
+)
+
+func TestNewNotNil(t *testing.T) {
+	for _, treeName := range newValueChildrenTestTrees {
+		t.Run(treeName+" not nil", func(t *testing.T) {
+			tree := mkTestTree(treeName)
+			if tree == nil {
+				t.Fatalf("tree should not be nil: %v", treeName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
@norbs57 noticed that if you run the test on the website for the new pov exercise without changing the stub, the test is wrongly reported as passing. For reasons that are not really clear to me, the test failure in that exercise is not reported with the test name but just on package level. The test runner was ignoring all output lines that were not associated with a specific test case what lead to the wrong "passing" status.

This PR fixed the issue that pkg level output is ignored when there is no test level output.

Additionally, I will open another issue for changing the structure of the tests so that the output will be reported with the test case field. Nevertheless, I think it is good to fix the general test runner issue here in case it happens again for other exercises.
