### PR TITLE
Test bumping of versions for label sync

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -86,6 +86,30 @@
   description: "Work on Test Runners"
   color: "ffffff"
 
+# The `x:rep/<value>` labels describe the amount of reputation to award
+# 
+# For more information on reputation and how these labels should be used,
+# check out https://exercism.org/docs/using/product/reputation
+- name: "x:rep/tiny"
+  description: "Tiny amount of reputation"
+  color: "ffffff"
+
+- name: "x:rep/small"
+  description: "Small amount of reputation"
+  color: "ffffff"
+
+- name: "x:rep/medium"
+  description: "Medium amount of reputation"
+  color: "ffffff"
+
+- name: "x:rep/large"
+  description: "Large amount of reputation"
+  color: "ffffff"
+
+- name: "x:rep/massive"
+  description: "Massive amount of reputation"
+  color: "ffffff"
+
 # The `x:size/<value>` labels describe the expected amount of work for a contributor
 - name: "x:size/tiny"
   description: "Tiny amount of work"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,15 +8,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: 1.17.x
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Run linters
-      uses: golangci/golangci-lint-action@v2
+      uses: golangci/golangci-lint-action@v3
       with:
-        version: v1.43
+        version: v1.45
 
   test:
     strategy:
@@ -28,11 +28,11 @@ jobs:
     steps:
     - name: Install Go
       if: success()
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Run tests
       run: go test ./... -v -covermode=count
 
@@ -41,11 +41,11 @@ jobs:
     steps:
     - name: Install Go
       if: success()
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: 1.17.x
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Calc coverage
       run: |
         go test ./... -v -covermode=count -coverprofile=coverage.out


### PR DESCRIPTION
This PR includes the changes of #73 but also bumps the versions of the actions used, which makes CI happy.