### PR TITLE
eliminate the redundant empty line in the extracted individual test case

### DIFF
--- a/testrunner/extract_test.go
+++ b/testrunner/extract_test.go
@@ -196,26 +196,30 @@ func TestExtractTestCode(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// whitespace / tabs were difficult to match between the test files
-			// and the test code / strings... so strip them
 			code := ExtractTestCode(tt.testName, tt.testFile)
 
-			loc := len(strings.Split(code, "\n"))
-			ttloc := len(strings.Split(tt.code, "\n"))
+			actualLines := strings.Split(code, "\n")
+			expectedLines := strings.Split(tt.code, "\n")
 
-			code = strings.Join(strings.Fields(code), " ")
-			ttcode := strings.Join(strings.Fields(tt.code), " ")
-			if code != ttcode {
-				t.Errorf("ExtractTestCode(%v, %v) = \n%v\n; want \n%v",
-					tt.testName, tt.testFile, code, ttcode)
+			if len(actualLines) != len(expectedLines) {
+				t.Errorf("ExtractTestCode(%v, %v)\n has %v lines\n; want %v lines",
+					tt.testName, tt.testFile, len(actualLines), len(expectedLines))
 			}
 
-			// check that extracted code has the expected number of lines.
-			// makes sure there's no redundant empty line in test data anonymous struct
-			// github/issues#79
-			if loc != ttloc {
-				t.Errorf("ExtractTestCode(%v, %v)\n has %v lines; want %v lines",
-					tt.testName, tt.testFile, loc, ttloc)
+			for i, actual := range actualLines {
+				expected := expectedLines[i]
+				// whitespace / tabs were difficult to match between the test files
+				// and the test code / strings... so strip them
+				actual = strings.Join(strings.Fields(actual), " ")
+				expected = strings.Join(strings.Fields(expected), " ")
+
+				if actual != expected {
+					t.Errorf("ExtractTestCode(%v, %v) = \n%v\n; want\n%v\n"+
+						"; differ on line: %v\n; have: `%v`\n; want: `%v`",
+						tt.testName, tt.testFile, code, tt.code,
+						i+1, actualLines[i], expectedLines[i])
+					break
+				}
 			}
 		})
 	}

--- a/testrunner/extract_test.go
+++ b/testrunner/extract_test.go
@@ -105,6 +105,7 @@ func TestExtractTestCode(t *testing.T) {
 	if got := ParseCard(tt.card); got != tt.want {
 		t.Errorf("ParseCard(%s) = %d, want %d", tt.card, got, tt.want)
 	}
+
 }`,
 		}, {
 			name:     "working subtest",
@@ -116,7 +117,6 @@ func TestExtractTestCode(t *testing.T) {
 		card string
 		want int
 	}{
-	
 		name: "parse jack",
 		card: "jack",
 		want: 10,
@@ -134,6 +134,7 @@ func TestExtractTestCode(t *testing.T) {
 			code: `func TestBlackjack(t *testing.T) {
 	someAssignment := "test"
 	fmt.Println(someAssignment)
+
 	type hand struct {
 		card1, card2 string
 	}
@@ -198,11 +199,23 @@ func TestExtractTestCode(t *testing.T) {
 			// whitespace / tabs were difficult to match between the test files
 			// and the test code / strings... so strip them
 			code := ExtractTestCode(tt.testName, tt.testFile)
+
+			loc := len(strings.Split(code, "\n"))
+			ttloc := len(strings.Split(tt.code, "\n"))
+
 			code = strings.Join(strings.Fields(code), " ")
 			ttcode := strings.Join(strings.Fields(tt.code), " ")
 			if code != ttcode {
 				t.Errorf("ExtractTestCode(%v, %v) = \n%v\n; want \n%v",
 					tt.testName, tt.testFile, code, ttcode)
+			}
+
+			// check that extracted code has the expected number of lines.
+			// makes sure there's no redundant empty line in test data anonymous struct
+			// github/issues#79
+			if loc != ttloc {
+				t.Errorf("ExtractTestCode(%v, %v)\n has %v lines; want %v lines",
+					tt.testName, tt.testFile, loc, ttloc)
 			}
 		})
 	}


### PR DESCRIPTION
Addresses #79

The redundant empty line can be traced to "ast.go", where the `Elts` attribute of the AST-node representing the slice of all test cases is replaced with the `Elts` attribute of an AST-node representing an individual test case.
It can be observed in the following diff of the (partial) AST:
<img width="824" alt="redundant-line-ast" src="https://user-images.githubusercontent.com/14804552/194154645-59be29ea-00b8-44b0-b206-1576f0b538e0.png">

I opted for replacing all of the contents of the slice-node (not just `Elts`, but also `Lbrace`)