### PR TITLE
Cover the case when `Run()` body is composed of multiple statements

### DIFF
--- a/testrunner/extract_test.go
+++ b/testrunner/extract_test.go
@@ -128,7 +128,7 @@ func TestExtractTestCode(t *testing.T) {
 
 }`,
 		}, {
-			name:     "subtest with additional code above and below test data",
+			name:     "subtest with additional code above and below test data, and multiple statements inside Run()",
 			testName: "TestBlackjack/blackjack_with_ten_(ace_first)",
 			testFile: tf,
 			code: `func TestBlackjack(t *testing.T) {
@@ -149,7 +149,8 @@ func TestExtractTestCode(t *testing.T) {
 
 	_ = "literally anything"
 	
-	if got := IsBlackjack(tt.hand.card1, tt.hand.card2); got != tt.want {
+	got := IsBlackjack(tt.hand.card1, tt.hand.card2)
+	if got != tt.want {
 		t.Errorf("IsBlackjack(%s, %s) = %t, want %t", tt.hand.card1, tt.hand.card2, got, tt.want)
 	}
 

--- a/testrunner/testdata/concept/conditionals/conditionals_test.go
+++ b/testrunner/testdata/concept/conditionals/conditionals_test.go
@@ -106,7 +106,8 @@ func TestBlackjack(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := IsBlackjack(tt.hand.card1, tt.hand.card2); got != tt.want {
+			got := IsBlackjack(tt.hand.card1, tt.hand.card2)
+			if got != tt.want {
 				t.Errorf("IsBlackjack(%s, %s) = %t, want %t", tt.hand.card1, tt.hand.card2, got, tt.want)
 			}
 		})


### PR DESCRIPTION
There are a few exercises that have tests with subtests and where the body of the `Run()` consists of multiple statements.
The extracted test then would only contain the first of these statements.
Below is a screenshot-example from the Cars Assemble exercise.
![image](https://user-images.githubusercontent.com/14804552/197057615-80ad45e6-6c93-407f-a0b3-36c4e9e8881c.png)
