### PR TITLE
Fix windows tests

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -47,49 +47,51 @@ var regexReplacements = []struct {
 }
 
 func TestIntegration(t *testing.T) {
+
 	tests := []struct {
 		inputDir string
 		expected string
 	}{
+
 		{
 			// This test case covers the case the code under test does not compile,
 			// i.e. "go build ." would fail.
-			inputDir: "./testrunner/testdata/practice/broken",
-			expected: "./testrunner/testdata/expected/broken.json",
+			inputDir: filepath.Join("testrunner", "testdata", "practice", "broken"),
+			expected: filepath.Join("testrunner", "testdata", "expected", "broken.json"),
 		},
 		{
 			// This test case covers the case that the test code does not compile,
 			// i.e. "go build ." would succeed but "go test" returns compilation errors.
-			inputDir: "./testrunner/testdata/practice/missing_func",
-			expected: "./testrunner/testdata/expected/missing_func.json",
+			inputDir: filepath.Join("testrunner", "testdata", "practice", "missing_func"),
+			expected: filepath.Join("testrunner", "testdata", "expected", "missing_func.json"),
 		},
 		{
-			inputDir: "./testrunner/testdata/practice/broken_import",
-			expected: "./testrunner/testdata/expected/broken_import.json",
+			inputDir: filepath.Join("testrunner", "testdata", "practice", "broken_import"),
+			expected: filepath.Join("testrunner", "testdata", "expected", "broken_import.json"),
 		},
 		{
-			inputDir: "./testrunner/testdata/practice/passing",
-			expected: "./testrunner/testdata/expected/passing.json",
+			inputDir: filepath.Join("testrunner", "testdata", "practice", "passing"),
+			expected: filepath.Join("testrunner", "testdata", "expected", "passing.json"),
 		},
 		{
-			inputDir: "./testrunner/testdata/practice/pkg_level_error",
-			expected: "./testrunner/testdata/expected/pkg_level_error.json",
+			inputDir: filepath.Join("testrunner", "testdata", "practice", "pkg_level_error"),
+			expected: filepath.Join("testrunner", "testdata", "expected", "pkg_level_error.json"),
 		},
 		{
-			inputDir: "./testrunner/testdata/practice/failing",
-			expected: "./testrunner/testdata/expected/failing.json",
+			inputDir: filepath.Join("testrunner", "testdata", "practice", "failing"),
+			expected: filepath.Join("testrunner", "testdata", "expected", "failing.json"),
 		},
 		{
-			inputDir: "./testrunner/testdata/concept/auto_assigned_task_ids",
-			expected: "./testrunner/testdata/expected/auto_assigned_task_ids.json",
+			inputDir: filepath.Join("testrunner", "testdata", "concept", "auto_assigned_task_ids"),
+			expected: filepath.Join("testrunner", "testdata", "expected", "auto_assigned_task_ids.json"),
 		},
 		{
-			inputDir: "./testrunner/testdata/concept/explicit_task_ids",
-			expected: "./testrunner/testdata/expected/explicit_task_ids.json",
+			inputDir: filepath.Join("testrunner", "testdata", "concept", "explicit_task_ids"),
+			expected: filepath.Join("testrunner", "testdata", "expected", "explicit_task_ids.json"),
 		},
 		{
-			inputDir: "./testrunner/testdata/concept/missing_task_ids",
-			expected: "./testrunner/testdata/expected/missing_task_ids.json",
+			inputDir: filepath.Join("testrunner", "testdata", "concept", "missing_task_ids"),
+			expected: filepath.Join("testrunner", "testdata", "expected", "missing_task_ids.json"),
 		},
 	}
 
@@ -106,7 +108,7 @@ func TestIntegration(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.inputDir, func(t *testing.T) {
-			err := os.RemoveAll("./outdir")
+			err := os.RemoveAll("outdir")
 			require.NoError(t, err, "failed to clean up output directory")
 
 			var stdout, stderr bytes.Buffer
@@ -119,7 +121,7 @@ func TestIntegration(t *testing.T) {
 			err = cmd.Run()
 			require.NoErrorf(t, err, "failed to execute test runner: %s %s", stdout.String(), stderr.String())
 
-			resultBytes, err := os.ReadFile("./outdir/results.json")
+			resultBytes, err := os.ReadFile(filepath.Join("outdir", "results.json"))
 			require.NoError(t, err, "failed to read results")
 
 			result := sanitizeResult(string(resultBytes), []string{goExe, currentDir, goRoot})

--- a/main_test.go
+++ b/main_test.go
@@ -4,12 +4,17 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 )
 
 func ExampleMain() {
-	os.Args = []string{"path", "testrunner/testdata/practice/passing", "outdir"}
+	os.Args = []string{
+		"path",
+		filepath.Join("testrunner", "testdata", "practice", "passing"),
+		"outdir",
+	}
 	main()
 	// Output:
 }
@@ -79,9 +84,9 @@ func TestCheckArgs(t *testing.T) {
 		{
 			name:       "broken output_dir",
 			input_dir:  "testrunner",
-			output_dir: "/tmp/broken/rmme",
+			output_dir: filepath.Join("/", "tmp", "broken", "rmme"),
 			ok:         false,
-			msg:        "output_dir /tmp/broken/rmme does not exist, mkdir failed:",
+			msg:        "output_dir " + filepath.Join("/", "tmp", "broken", "rmme") + " does not exist, mkdir failed:",
 		},
 	}
 	for _, tt := range tests {

--- a/testrunner/ast_test.go
+++ b/testrunner/ast_test.go
@@ -1,6 +1,7 @@
 package testrunner
 
 import (
+	"path/filepath"
 	"testing"
 )
 
@@ -14,17 +15,17 @@ func TestGetFuncCode(t *testing.T) {
 		{
 			name:     "valid call",
 			testName: "TestNonSubtest",
-			testFile: "testdata/concept/conditionals/conditionals_test.go",
+			testFile: filepath.Join("testdata", "concept", "conditionals", "conditionals_test.go"),
 			code:     "func TestNonSubtest(t *testing.T) {\n\t// comments should be included\n\tfmt.Println(\"the whole block\")\n\tfmt.Println(\"should be returned\")\n}",
 		}, {
 			name:     "missing test",
 			testName: "TestNothing",
-			testFile: "testdata/concept/conditionals/conditionals_test.go",
+			testFile: filepath.Join("testdata", "concept", "conditionals", "conditionals_test.go"),
 			code:     "",
 		}, {
 			name:     "invalid test file",
 			testName: "TestNonSubtest",
-			testFile: "testdata/concept/conditionals/conditionals_missing.go",
+			testFile: filepath.Join("testdata", "concept", "conditionals", "conditionals_missing.go"),
 			code:     "",
 		},
 	}

--- a/testrunner/execute.go
+++ b/testrunner/execute.go
@@ -360,7 +360,7 @@ func testCompiles(input_dir string) bool {
 		Path: goExe,
 		// "Official" recommendation for compiling but not running the tests
 		// https://github.com/golang/go/issues/46712#issuecomment-859949958
-		Args:   []string{goExe, "test", "-c", "-o", "/dev/null"},
+		Args:   []string{goExe, "test", "-c", "-o", os.DevNull},
 		Stdout: &stdout,
 		Stderr: &stderr,
 	}

--- a/testrunner/execute_test.go
+++ b/testrunner/execute_test.go
@@ -3,6 +3,7 @@ package testrunner
 import (
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -16,7 +17,7 @@ const version = 3
 */
 
 func TestRunTests_RuntimeError(t *testing.T) {
-	input_dir := "./testdata/practice/runtime_error"
+	input_dir := filepath.Join("testdata", "practice", "runtime_error")
 	cmdres, ok := runTests(input_dir, nil)
 	if !ok {
 		fmt.Printf("runtime error test expected to return ok: %s", cmdres.String())
@@ -46,7 +47,8 @@ func TestRunTests_RuntimeError(t *testing.T) {
 }
 
 func TestRunTests_RaceDetector(t *testing.T) {
-	input_dir := "./testdata/practice/race"
+
+	input_dir := filepath.Join("testdata", "practice", "race")
 	cmdres, ok := runTests(input_dir, []string{"-race"})
 	if !ok {
 		fmt.Printf("race detector test expected to return ok: %s", cmdres.String())

--- a/testrunner/extract_test.go
+++ b/testrunner/extract_test.go
@@ -1,7 +1,7 @@
 package testrunner
 
 import (
-	"runtime"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -37,11 +37,6 @@ func TestSplitTestName(t *testing.T) {
 }
 
 func TestFindTestFile(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		// The test data is set up for non-windows file paths currently.
-		t.Skip()
-	}
-
 	tests := []struct {
 		name     string
 		testName string
@@ -51,13 +46,13 @@ func TestFindTestFile(t *testing.T) {
 		{
 			name:     "found test",
 			testName: "TestBlackjack",
-			codePath: "testdata/concept/conditionals",
-			fileName: "testdata/concept/conditionals/conditionals_test.go",
+			codePath: filepath.Join("testdata", "concept", "conditionals"),
+			fileName: filepath.Join("testdata", "concept", "conditionals", "conditionals_test.go"),
 		}, {
 			name:     "found subtest",
 			testName: "TestBlackjack/blackjack_with_jack_(ace_first)",
-			codePath: "testdata/concept/conditionals",
-			fileName: "testdata/concept/conditionals/conditionals_test.go",
+			codePath: filepath.Join("testdata", "concept", "conditionals"),
+			fileName: filepath.Join("testdata", "concept", "conditionals", "conditionals_test.go"),
 		}, {
 			name:     "missing test",
 			testName: "TestMissing",
@@ -76,7 +71,7 @@ func TestFindTestFile(t *testing.T) {
 }
 
 func TestExtractTestCode(t *testing.T) {
-	tf := "testdata/concept/conditionals/conditionals_test.go"
+	tf := filepath.Join("testdata", "concept", "conditionals", "conditionals_test.go")
 	tests := []struct {
 		name     string
 		testName string
@@ -168,7 +163,7 @@ func TestExtractTestCode(t *testing.T) {
 		}, {
 			name:     "missing / not found subtest",
 			testName: "TestParseCard/parse_missing_subtests",
-			testFile: "testdata/concept/conditionals/conditionals_test.go",
+			testFile: filepath.Join("testdata", "concept", "conditionals", "conditionals_test.go"),
 			code: `func TestParseCard(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
Previously the tests for the test runner were failing on Windows, mainly due to differences in path issues.

This PR fixes those issues and unskips a test previously being skipped.

Ran tests on Mac and Windows, and all are passing.
- For Windows, tests requiring the race detector only worked when I used [tdm-gcc](https://jmeubank.github.io/tdm-gcc/) as the C toolchain.