### PR TITLE
Add non-executed tests to result set

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,5 +225,13 @@ Otherwise no task ids will be set at all.
 
 Finding the task id is robust again other comments before or after or in the same line as the `testRunnerTaskID` comment, see the [conditionals-with-task-ids test file][task-id-comments-examples] for examples.
 
+## Known limitations
+
+Besides what is mentioned in the open issues, the test runner has the following limitations currently.
+
+- The test runner assumes all test functions `func Test...` can be found in one file.
+- The `cases_test.go` file is ignored when extracting the code for the test.
+- Sub-tests need to follow a certain format, see details above.
+
 [task-id]: https://exercism.org/docs/building/tooling/test-runners/interface#h-task-id
 [task-id-comments-examples]: https://github.com/exercism/go-test-runner/tree/main/testrunner/testdata/concept/conditionals-with-task-ids

--- a/integration_test.go
+++ b/integration_test.go
@@ -47,12 +47,10 @@ var regexReplacements = []struct {
 }
 
 func TestIntegration(t *testing.T) {
-
 	tests := []struct {
 		inputDir string
 		expected string
 	}{
-
 		{
 			// This test case covers the case the code under test does not compile,
 			// i.e. "go build ." would fail.
@@ -92,6 +90,10 @@ func TestIntegration(t *testing.T) {
 		{
 			inputDir: filepath.Join("testrunner", "testdata", "concept", "missing_task_ids"),
 			expected: filepath.Join("testrunner", "testdata", "expected", "missing_task_ids.json"),
+		},
+		{
+			inputDir: filepath.Join("testrunner", "testdata", "concept", "non_executed_tests"),
+			expected: filepath.Join("testrunner", "testdata", "expected", "non_executed_tests.json"),
 		},
 	}
 

--- a/testrunner/ast.go
+++ b/testrunner/ast.go
@@ -29,25 +29,48 @@ type subTestAstInfo struct {
 	rangeAstIdx    int
 }
 
-// return the code of the "test" function from a file
-func getFuncCodeAndTaskID(test string, fstr string) (string, uint64) {
+type rootLevelTest struct {
+	name     string
+	fileName string
+	code     string
+	taskID   uint64
+}
+
+func FindAllRootLevelTests(fileName string) []rootLevelTest {
+	defer handleASTPanic()
+	// Create a map from test name to data for the test for easy retrieval later on.
+	tests := []rootLevelTest{}
 	fset := token.NewFileSet()
 	ppc := parser.ParseComments
-	file, err := parser.ParseFile(fset, fstr, nil, ppc)
+	file, err := parser.ParseFile(fset, fileName, nil, ppc)
 	if err != nil {
-		log.Printf("warning: '%s' not parsed from '%s': %s", test, fstr, err)
-		return "", 0
+		log.Printf("error: not able to parse '%s': %s", fileName, err)
+		return nil
 	}
 	for _, d := range file.Decls {
-		if f, ok := d.(*ast.FuncDecl); ok && f.Name.Name == test {
+		if f, ok := d.(*ast.FuncDecl); ok && strings.HasPrefix(f.Name.Name, "Test") {
 			taskID := findTaskID(f.Doc)
 			fun := &printer.CommentedNode{Node: f, Comments: file.Comments}
 			var buf bytes.Buffer
 			printer.Fprint(&buf, fset, fun)
-			return buf.String(), taskID
+
+			tests = append(tests, rootLevelTest{
+				name:     f.Name.Name,
+				fileName: fileName,
+				code:     buf.String(),
+				taskID:   taskID,
+			})
 		}
 	}
-	return "", 0
+	return tests
+}
+
+func ConvertToMapByTestName(tests []rootLevelTest) map[string]rootLevelTest {
+	result := map[string]rootLevelTest{}
+	for i := range tests {
+		result[tests[i].name] = tests[i]
+	}
+	return result
 }
 
 var taskIDFormat = regexp.MustCompile(`testRunnerTaskID=([0-9]+)`)

--- a/testrunner/ast_test.go
+++ b/testrunner/ast_test.go
@@ -17,12 +17,8 @@ func TestGetFuncCode(t *testing.T) {
 			testName: "TestNonSubtest",
 			testFile: filepath.Join("testdata", "concept", "conditionals", "conditionals_test.go"),
 			code:     "func TestNonSubtest(t *testing.T) {\n\t// comments should be included\n\tfmt.Println(\"the whole block\")\n\tfmt.Println(\"should be returned\")\n}",
-		}, {
-			name:     "missing test",
-			testName: "TestNothing",
-			testFile: filepath.Join("testdata", "concept", "conditionals", "conditionals_test.go"),
-			code:     "",
-		}, {
+		},
+		{
 			name:     "invalid test file",
 			testName: "TestNonSubtest",
 			testFile: filepath.Join("testdata", "concept", "conditionals", "conditionals_missing.go"),
@@ -31,9 +27,11 @@ func TestGetFuncCode(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if code, _ := getFuncCodeAndTaskID(tt.testName, tt.testFile); code != tt.code {
-				t.Errorf("getFuncCode(%v, %v) = %v; want %v",
-					tt.testName, tt.testFile, code, tt.code)
+			rootLevelTests := FindAllRootLevelTests(tt.testFile)
+			rootLevelTestsMap := ConvertToMapByTestName(rootLevelTests)
+			if rootLevelTestsMap[tt.testName].code != tt.code {
+				t.Errorf("FindAllRootLevelTests for %s did not return correct code, got %v; want %v",
+					tt.testFile, rootLevelTestsMap[tt.testName].code, tt.code)
 			}
 		})
 	}

--- a/testrunner/execute_test.go
+++ b/testrunner/execute_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const version = 3
@@ -61,5 +63,138 @@ func TestRunTests_RaceDetector(t *testing.T) {
 
 	if !strings.Contains(output.Tests[0].Message, "WARNING: DATA RACE") {
 		t.Errorf("no data race error included in message: %s", output.Tests[0].Message)
+	}
+}
+
+func TestAddNonExecutedTests(t *testing.T) {
+	tests := []struct {
+		name                string
+		inputRootLevelTests []rootLevelTest
+		inputResults        []testResult
+		expected            []testResult
+	}{
+		{
+			name: "works with no results",
+			inputRootLevelTests: []rootLevelTest{
+				{name: "TestSomething1"},
+				{name: "TestSomething2"},
+			},
+			inputResults: nil,
+			expected: []testResult{
+				{
+					Name:    "TestSomething1",
+					Status:  statErr,
+					Message: "This test was not executed.",
+				},
+				{
+					Name:    "TestSomething2",
+					Status:  statErr,
+					Message: "This test was not executed.",
+				},
+			},
+		},
+		{
+			name: "adds to end of the results",
+			inputRootLevelTests: []rootLevelTest{
+				{name: "TestSomething1"},
+				{name: "TestSomething2"},
+				{name: "TestSomething3"},
+				{name: "TestSomething4"},
+			},
+			inputResults: []testResult{
+				{Name: "TestSomething1"},
+				{Name: "TestSomething2/subtest1"},
+				{Name: "TestSomething2/subtest2"},
+			},
+			expected: []testResult{
+				{Name: "TestSomething1"},
+				{Name: "TestSomething2/subtest1"},
+				{Name: "TestSomething2/subtest2"},
+				{
+					Name:    "TestSomething3",
+					Status:  statErr,
+					Message: "This test was not executed.",
+				},
+				{
+					Name:    "TestSomething4",
+					Status:  statErr,
+					Message: "This test was not executed.",
+				},
+			},
+		},
+		{
+			name: "adds to the beginning of the results",
+			inputRootLevelTests: []rootLevelTest{
+				{name: "TestSomething1"},
+				{name: "TestSomething2"},
+				{name: "TestSomething3"},
+				{name: "TestSomething4"},
+			},
+			inputResults: []testResult{
+				{Name: "TestSomething3"},
+				{Name: "TestSomething4/subtest1"},
+				{Name: "TestSomething4/subtest2"},
+			},
+			expected: []testResult{
+				{
+					Name:    "TestSomething1",
+					Status:  statErr,
+					Message: "This test was not executed.",
+				},
+				{
+					Name:    "TestSomething2",
+					Status:  statErr,
+					Message: "This test was not executed.",
+				},
+				{Name: "TestSomething3"},
+				{Name: "TestSomething4/subtest1"},
+				{Name: "TestSomething4/subtest2"},
+			},
+		},
+		{
+			name: "can add results in the middle",
+			inputRootLevelTests: []rootLevelTest{
+				{name: "TestSomething1"},
+				{name: "TestSomething2"},
+				{name: "TestSomething3"},
+				{name: "TestSomething4"},
+				{name: "TestSomething5"},
+				{name: "TestSomething6"},
+			},
+			inputResults: []testResult{
+				{Name: "TestSomething1/subtest1"},
+				{Name: "TestSomething1/subtest2"},
+				{Name: "TestSomething3"},
+				{Name: "TestSomething6"},
+			},
+			expected: []testResult{
+				{Name: "TestSomething1/subtest1"},
+				{Name: "TestSomething1/subtest2"},
+				{
+					Name:    "TestSomething2",
+					Status:  statErr,
+					Message: "This test was not executed.",
+				},
+				{Name: "TestSomething3"},
+				{
+					Name:    "TestSomething4",
+					Status:  statErr,
+					Message: "This test was not executed.",
+				},
+				{
+					Name:    "TestSomething5",
+					Status:  statErr,
+					Message: "This test was not executed.",
+				},
+				{Name: "TestSomething6"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := addNonExecutedTests(tt.inputRootLevelTests, tt.inputResults)
+			assert.Equal(t, tt.expected, result)
+		})
 	}
 }

--- a/testrunner/extract_test.go
+++ b/testrunner/extract_test.go
@@ -39,32 +39,25 @@ func TestSplitTestName(t *testing.T) {
 func TestFindTestFile(t *testing.T) {
 	tests := []struct {
 		name     string
-		testName string
 		codePath string
 		fileName string
 	}{
 		{
-			name:     "found test",
-			testName: "TestBlackjack",
+			name:     "found single test file",
+			codePath: filepath.Join("testdata", "practice", "passing"),
+			fileName: filepath.Join("testdata", "practice", "passing", "passing_test.go"),
+		},
+		{
+			name:     "found correct test file if there are two",
 			codePath: filepath.Join("testdata", "concept", "conditionals"),
 			fileName: filepath.Join("testdata", "concept", "conditionals", "conditionals_test.go"),
-		}, {
-			name:     "found subtest",
-			testName: "TestBlackjack/blackjack_with_jack_(ace_first)",
-			codePath: filepath.Join("testdata", "concept", "conditionals"),
-			fileName: filepath.Join("testdata", "concept", "conditionals", "conditionals_test.go"),
-		}, {
-			name:     "missing test",
-			testName: "TestMissing",
-			codePath: "",
-			fileName: "",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tf := findTestFile(tt.testName, tt.codePath); tf != tt.fileName {
-				t.Errorf("findTestFile(%v, %v) = %v; want %v",
-					tt.testName, tt.codePath, tf, tt.fileName)
+			if tf := FindTestFile(tt.codePath); tf != tt.fileName {
+				t.Errorf("findTestFile(%v) = %v; want %v",
+					tt.codePath, tf, tt.fileName)
 			}
 		})
 	}
@@ -72,6 +65,8 @@ func TestFindTestFile(t *testing.T) {
 
 func TestExtractTestCode(t *testing.T) {
 	tf := filepath.Join("testdata", "concept", "conditionals", "conditionals_test.go")
+	rootLevelTests := FindAllRootLevelTests(tf)
+	rootLevelTestsMap := ConvertToMapByTestName(rootLevelTests)
 	tests := []struct {
 		name     string
 		testName string
@@ -198,7 +193,7 @@ func TestExtractTestCode(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			code, _ := ExtractTestCodeAndTaskID(tt.testName, tt.testFile)
+			code, _ := ExtractTestCodeAndTaskID(rootLevelTestsMap, tt.testName)
 
 			actualLines := strings.Split(code, "\n")
 			expectedLines := strings.Split(tt.code, "\n")

--- a/testrunner/testdata/concept/conditionals/cases_test.go
+++ b/testrunner/testdata/concept/conditionals/cases_test.go
@@ -1,0 +1,21 @@
+package conditionals
+
+type allergicToInput struct {
+	allergen string
+	score    uint
+}
+
+var allergicToTests = []struct {
+	description string
+	input       allergicToInput
+	expected    bool
+}{
+	{
+		description: "not allergic to anything",
+		input: allergicToInput{
+			allergen: "eggs",
+			score:    0,
+		},
+		expected: false,
+	},
+}

--- a/testrunner/testdata/concept/non_executed_tests/.meta/config.json
+++ b/testrunner/testdata/concept/non_executed_tests/.meta/config.json
@@ -1,0 +1,26 @@
+{
+  "authors": [
+    "bobtfish"
+  ],
+  "contributors": [
+    "sougat818"
+  ],
+  "files": {
+    "solution": [
+      "lasagna_master.go"
+    ],
+    "test": [
+      "lasagna_master_test.go"
+    ],
+    "exemplar": [
+      ".meta/exemplar.go"
+    ]
+  },
+  "forked_from": [
+    "javascript/lasagna-master"
+  ],
+  "blurb": "Dive deeper into Go functions while preparing to cook the perfect lasagna.",
+  "custom": {
+    "taskIdsEnabled": true
+  }
+}

--- a/testrunner/testdata/concept/non_executed_tests/go.mod
+++ b/testrunner/testdata/concept/non_executed_tests/go.mod
@@ -1,0 +1,3 @@
+module lasagna
+
+go 1.16

--- a/testrunner/testdata/concept/non_executed_tests/lasagna_master.go
+++ b/testrunner/testdata/concept/non_executed_tests/lasagna_master.go
@@ -1,0 +1,24 @@
+package lasagna
+
+// PreparationTim estimates the preparation time based on the number of layers and an average time per layer and returns it.
+func PreparationTime(layers []string, avgPrepTime int) int {
+	if avgPrepTime == 0 {
+		avgPrepTime = 2
+	}
+	return len(layers) * avgPrepTime
+}
+
+// Quantities calculates and returns how many noodles and much sauce are needed for the given layers.
+func Quantities(layers []string) (noodles int, sauce float64) {
+	panic("Please implement")
+}
+
+// AddSecretIngredient replaces the secret ingredient of your list with the last ingredient from your friend's list.
+func AddSecretIngredient(friendsList, myList []string) {
+	panic("Please implement")
+}
+
+// ScaleRecipe makes a new slice of float64s from an input slice scaled by a number of portions.
+func ScaleRecipe(list []float64, portions int) []float64 {
+	panic("Please implement")
+}

--- a/testrunner/testdata/concept/non_executed_tests/lasagna_master_test.go
+++ b/testrunner/testdata/concept/non_executed_tests/lasagna_master_test.go
@@ -1,0 +1,219 @@
+package lasagna
+
+import (
+	"math"
+	"reflect"
+	"testing"
+)
+
+type preparationTimeTests struct {
+	name           string
+	layers         []string
+	time, expected int
+}
+
+func TestPreparationTime(t *testing.T) {
+	tests := []preparationTimeTests{
+		{
+			name: "Preparation time for many layers with custom average time",
+			layers: []string{
+				"sauce",
+				"noodles",
+				"béchamel",
+				"meat",
+				"mozzarella",
+				"noodles",
+				"ricotta",
+				"eggplant",
+				"béchamel",
+				"noodles",
+				"sauce",
+				"mozzarella",
+			},
+			time:     1,
+			expected: 12,
+		},
+		{
+			name: "Preparation time for few layers",
+			layers: []string{
+				"sauce",
+				"noodles",
+			},
+			time:     3,
+			expected: 6,
+		},
+		{
+			name: "Preparation time for default case",
+			layers: []string{
+				"sauce",
+				"noodles",
+			},
+			time:     0,
+			expected: 4,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := PreparationTime(tt.layers, tt.time); got != tt.expected {
+				t.Errorf("PreparationTime(%v, %d) = %d; want %d", tt.layers, tt.time, got, tt.expected)
+			}
+		})
+
+	}
+}
+
+type quantitiesTest struct {
+	name       string
+	layers     []string
+	expNoodles int
+	expSauce   float64
+}
+
+func TestQuantities(t *testing.T) {
+	tests := []quantitiesTest{
+		{
+			name:       "few layers",
+			layers:     []string{"noodles", "sauce", "noodles"},
+			expNoodles: 100,
+			expSauce:   0.2,
+		},
+		{
+			name: "many layers",
+			layers: []string{
+				"sauce",
+				"noodles",
+				"béchamel",
+				"meat",
+				"mozzarella",
+				"noodles",
+				"ricotta",
+				"eggplant",
+				"béchamel",
+				"noodles",
+				"sauce",
+				"mozzarella"},
+			expNoodles: 150,
+			expSauce:   0.4,
+		},
+		{
+			name: "no noodles",
+			layers: []string{
+				"sauce",
+				"meat",
+				"mozzarella",
+				"sauce",
+				"mozzarella"},
+			expNoodles: 0,
+			expSauce:   0.4,
+		},
+		{
+			name: "no sauce",
+			layers: []string{
+				"noodles",
+				"meat",
+				"mozzarella",
+				"noodles",
+				"mozzarella"},
+			expNoodles: 100,
+			expSauce:   0.0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotNoodles, gotSauce := Quantities(tt.layers)
+			if gotNoodles != tt.expNoodles {
+				t.Errorf("quantities(%v) = %d noodles; want %d", tt.layers, gotNoodles, tt.expNoodles)
+			}
+			if gotSauce != tt.expSauce {
+				t.Errorf("quantities(%v) = %f sauce; want %f", tt.layers, gotSauce, tt.expSauce)
+			}
+		})
+	}
+}
+
+type secretTest struct {
+	name        string
+	friendsList []string
+	myList      []string
+	expected    []string
+}
+
+func TestAddSecretIngredient(t *testing.T) {
+	tests := []secretTest{
+		{
+			name:        "Adds secret ingredient",
+			friendsList: []string{"sauce", "noodles", "béchamel", "marjoram"},
+			myList:      []string{"sauce", "noodles", "meat", "tomatoes", "?"},
+			expected:    []string{"sauce", "noodles", "meat", "tomatoes", "marjoram"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			friendsList := make([]string, len(tt.friendsList))
+			copy(friendsList, tt.friendsList)
+			myList := make([]string, len(tt.myList))
+			copy(myList, tt.myList)
+			AddSecretIngredient(tt.friendsList, tt.myList)
+			if !reflect.DeepEqual(tt.myList, tt.expected) {
+				t.Errorf("addSecretIngredient(%v, %v) = %v want %v", tt.friendsList, myList, tt.myList, tt.expected)
+			}
+			if !reflect.DeepEqual(friendsList, tt.friendsList) {
+				t.Errorf("addSecretIngredient permuted friendsList (was %v, now %v), should not alter inputs", tt.friendsList, friendsList)
+			}
+		})
+	}
+}
+
+type scaleRecipeTest struct {
+	name     string
+	input    []float64
+	portions int
+	expected []float64
+}
+
+func TestScaleRecipe(t *testing.T) {
+	tests := []scaleRecipeTest{
+		{
+			name:     "scales up correctly",
+			input:    []float64{0.5, 250, 150, 3, 0.5},
+			portions: 6,
+			expected: []float64{1.5, 750, 450, 9, 1.5},
+		},
+		{
+			name:     "scales up correctly (2)",
+			input:    []float64{0.6, 300, 1, 0.5, 50, 0.1, 100},
+			portions: 3,
+			expected: []float64{0.9, 450, 1.5, 0.75, 75, 0.15, 150},
+		},
+		{
+			name:     "scales down correctly",
+			input:    []float64{0.5, 250, 150, 3, 0.5},
+			portions: 1,
+			expected: []float64{0.25, 125, 75, 1.5, 0.25},
+		},
+		{
+			name:     "empty recipe",
+			input:    []float64{},
+			portions: 100,
+			expected: []float64{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inputList := make([]float64, len(tt.input))
+			copy(inputList, tt.input)
+			got := ScaleRecipe(inputList, tt.portions)
+			if len(got) != len(tt.expected) {
+				t.Errorf("ScaleRecipe(%v, %d) produced slice of length %d, expected %d", inputList, tt.portions, len(got), len(tt.expected))
+			}
+			for i := range tt.expected {
+				if math.Abs(got[i]-tt.expected[i]) > 0.000001 {
+					t.Errorf("Got %f Expected %f for index %d", got[i], tt.expected[i], i)
+				}
+			}
+			if !reflect.DeepEqual(inputList, tt.input) {
+				t.Errorf("ScaleRecipe permuted list (was %v, now %v), should not alter inputs", tt.input, inputList)
+			}
+		})
+	}
+}

--- a/testrunner/testdata/expected/non_executed_tests.json
+++ b/testrunner/testdata/expected/non_executed_tests.json
@@ -1,0 +1,48 @@
+{
+	"status": "fail",
+	"version": 3,
+	"tests": [
+		{
+			"name": "TestPreparationTime/ Preparation time for many layers with custom average time",
+			"status": "pass",
+			"test_code": "func TestPreparationTime(t *testing.T) {\n\ttt := preparationTimeTests{\n\t\tname: \"Preparation time for many layers with custom average time\",\n\t\tlayers: []string{\n\t\t\t\"sauce\",\n\t\t\t\"noodles\",\n\t\t\t\"béchamel\",\n\t\t\t\"meat\",\n\t\t\t\"mozzarella\",\n\t\t\t\"noodles\",\n\t\t\t\"ricotta\",\n\t\t\t\"eggplant\",\n\t\t\t\"béchamel\",\n\t\t\t\"noodles\",\n\t\t\t\"sauce\",\n\t\t\t\"mozzarella\",\n\t\t},\n\t\ttime:     1,\n\t\texpected: 12,\n\t}\n\n\tif got := PreparationTime(tt.layers, tt.time); got != tt.expected {\n\t\tt.Errorf(\"PreparationTime(%v, %d) = %d; want %d\", tt.layers, tt.time, got, tt.expected)\n\t}\n\n}",
+			"message": "\n=== RUN   TestPreparationTime/Preparation_time_for_many_layers_with_custom_average_time\n\n--- PASS: TestPreparationTime/Preparation_time_for_many_layers_with_custom_average_time \n",
+			"task_id": 1
+		},
+		{
+			"name": "TestPreparationTime/ Preparation time for few layers",
+			"status": "pass",
+			"test_code": "func TestPreparationTime(t *testing.T) {\n\ttt := preparationTimeTests{\n\t\tname: \"Preparation time for few layers\",\n\t\tlayers: []string{\n\t\t\t\"sauce\",\n\t\t\t\"noodles\",\n\t\t},\n\t\ttime:     3,\n\t\texpected: 6,\n\t}\n\n\tif got := PreparationTime(tt.layers, tt.time); got != tt.expected {\n\t\tt.Errorf(\"PreparationTime(%v, %d) = %d; want %d\", tt.layers, tt.time, got, tt.expected)\n\t}\n\n}",
+			"message": "\n=== RUN   TestPreparationTime/Preparation_time_for_few_layers\n\n--- PASS: TestPreparationTime/Preparation_time_for_few_layers \n",
+			"task_id": 1
+		},
+		{
+			"name": "TestPreparationTime/ Preparation time for default case",
+			"status": "pass",
+			"test_code": "func TestPreparationTime(t *testing.T) {\n\ttt := preparationTimeTests{\n\t\tname: \"Preparation time for default case\",\n\t\tlayers: []string{\n\t\t\t\"sauce\",\n\t\t\t\"noodles\",\n\t\t},\n\t\ttime:     0,\n\t\texpected: 4,\n\t}\n\n\tif got := PreparationTime(tt.layers, tt.time); got != tt.expected {\n\t\tt.Errorf(\"PreparationTime(%v, %d) = %d; want %d\", tt.layers, tt.time, got, tt.expected)\n\t}\n\n}",
+			"message": "\n=== RUN   TestPreparationTime/Preparation_time_for_default_case\n\n--- PASS: TestPreparationTime/Preparation_time_for_default_case \n",
+			"task_id": 1
+		},
+		{
+			"name": "TestQuantities/ few layers",
+			"status": "fail",
+			"test_code": "func TestQuantities(t *testing.T) {\n\ttt := quantitiesTest{\n\t\tname:       \"few layers\",\n\t\tlayers:     []string{\"noodles\", \"sauce\", \"noodles\"},\n\t\texpNoodles: 100,\n\t\texpSauce:   0.2,\n\t}\n\n\tgotNoodles, gotSauce := Quantities(tt.layers)\n\tif gotNoodles != tt.expNoodles {\n\t\tt.Errorf(\"quantities(%v) = %d noodles; want %d\", tt.layers, gotNoodles, tt.expNoodles)\n\t}\n\tif gotSauce != tt.expSauce {\n\t\tt.Errorf(\"quantities(%v) = %f sauce; want %f\", tt.layers, gotSauce, tt.expSauce)\n\t}\n\n}",
+			"message": "\n=== RUN   TestQuantities/few_layers\n\n--- FAIL: TestQuantities/few_layers \n\npanic: Please implement [recovered]\n\n\tpanic: Please implement\n\n\n\ngoroutine x [running]:\n\ntesting.tRunner.func1.2({, })\n\n\tPATH_PLACEHOLDER/src/testing/testing.go \n\ntesting.tRunner.func1()\n\n\tPATH_PLACEHOLDER/src/testing/testing.go \n\npanic({, })\n\n\tPATH_PLACEHOLDER/src/runtime/panic.go \n\nlasagna.Quantities(...)\n\n\tPATH_PLACEHOLDER/testrunner/testdata/concept/non_executed_tests/lasagna_master.go\n\nlasagna.TestQuantities.func1?)\n\n\tPATH_PLACEHOLDER/testrunner/testdata/concept/non_executed_tests/lasagna_master_test.go \n\ntesting.tRunner, \n\n\tPATH_PLACEHOLDER/src/testing/testing.go \n\ncreated by testing.(*T).Run\n\n\tPATH_PLACEHOLDER/src/testing/testing.go \n",
+			"task_id": 2
+		},
+		{
+			"name": "TestAddSecretIngredient",
+			"status": "error",
+			"test_code": "func TestAddSecretIngredient(t *testing.T) {\n\ttests := []secretTest{\n\t\t{\n\t\t\tname:\t\t\"Adds secret ingredient\",\n\t\t\tfriendsList:\t[]string{\"sauce\", \"noodles\", \"béchamel\", \"marjoram\"},\n\t\t\tmyList:\t\t[]string{\"sauce\", \"noodles\", \"meat\", \"tomatoes\", \"?\"},\n\t\t\texpected:\t[]string{\"sauce\", \"noodles\", \"meat\", \"tomatoes\", \"marjoram\"},\n\t\t},\n\t}\n\tfor _, tt := range tests {\n\t\tt.Run(tt.name, func(t *testing.T) {\n\t\t\tfriendsList := make([]string, len(tt.friendsList))\n\t\t\tcopy(friendsList, tt.friendsList)\n\t\t\tmyList := make([]string, len(tt.myList))\n\t\t\tcopy(myList, tt.myList)\n\t\t\tAddSecretIngredient(tt.friendsList, tt.myList)\n\t\t\tif !reflect.DeepEqual(tt.myList, tt.expected) {\n\t\t\t\tt.Errorf(\"addSecretIngredient(%v, %v) = %v want %v\", tt.friendsList, myList, tt.myList, tt.expected)\n\t\t\t}\n\t\t\tif !reflect.DeepEqual(friendsList, tt.friendsList) {\n\t\t\t\tt.Errorf(\"addSecretIngredient permuted friendsList (was %v, now %v), should not alter inputs\", tt.friendsList, friendsList)\n\t\t\t}\n\t\t})\n\t}\n}",
+			"message": "This test was not executed.",
+			"task_id": 3
+		},
+		{
+			"name": "TestScaleRecipe",
+			"status": "error",
+			"test_code": "func TestScaleRecipe(t *testing.T) {\n\ttests := []scaleRecipeTest{\n\t\t{\n\t\t\tname:\t\t\"scales up correctly\",\n\t\t\tinput:\t\t[]float64{0.5, 250, 150, 3, 0.5},\n\t\t\tportions:\t6,\n\t\t\texpected:\t[]float64{1.5, 750, 450, 9, 1.5},\n\t\t},\n\t\t{\n\t\t\tname:\t\t\"scales up correctly (2)\",\n\t\t\tinput:\t\t[]float64{0.6, 300, 1, 0.5, 50, 0.1, 100},\n\t\t\tportions:\t3,\n\t\t\texpected:\t[]float64{0.9, 450, 1.5, 0.75, 75, 0.15, 150},\n\t\t},\n\t\t{\n\t\t\tname:\t\t\"scales down correctly\",\n\t\t\tinput:\t\t[]float64{0.5, 250, 150, 3, 0.5},\n\t\t\tportions:\t1,\n\t\t\texpected:\t[]float64{0.25, 125, 75, 1.5, 0.25},\n\t\t},\n\t\t{\n\t\t\tname:\t\t\"empty recipe\",\n\t\t\tinput:\t\t[]float64{},\n\t\t\tportions:\t100,\n\t\t\texpected:\t[]float64{},\n\t\t},\n\t}\n\tfor _, tt := range tests {\n\t\tt.Run(tt.name, func(t *testing.T) {\n\t\t\tinputList := make([]float64, len(tt.input))\n\t\t\tcopy(inputList, tt.input)\n\t\t\tgot := ScaleRecipe(inputList, tt.portions)\n\t\t\tif len(got) != len(tt.expected) {\n\t\t\t\tt.Errorf(\"ScaleRecipe(%v, %d) produced slice of length %d, expected %d\", inputList, tt.portions, len(got), len(tt.expected))\n\t\t\t}\n\t\t\tfor i := range tt.expected {\n\t\t\t\tif math.Abs(got[i]-tt.expected[i]) \u003e 0.000001 {\n\t\t\t\t\tt.Errorf(\"Got %f Expected %f for index %d\", got[i], tt.expected[i], i)\n\t\t\t\t}\n\t\t\t}\n\t\t\tif !reflect.DeepEqual(inputList, tt.input) {\n\t\t\t\tt.Errorf(\"ScaleRecipe permuted list (was %v, now %v), should not alter inputs\", tt.input, inputList)\n\t\t\t}\n\t\t})\n\t}\n}",
+			"message": "This test was not executed.",
+			"task_id": 4
+		}
+	]
+}


### PR DESCRIPTION
Fixes #94 

I think this also resolves #47 as good as we can. The number of tests will still vary because we only have "placeholders" for the parent tests and not for the subtests but generating placeholders for the dynamically created subtests would be rather hard. Also the new testrunenr version 3 UI mitigates the issue described there somewhat as the output is grouped by task.