### PR TITLE
Fix for non-executed test reporting

### DIFF
--- a/testrunner/ast.go
+++ b/testrunner/ast.go
@@ -36,9 +36,10 @@ type rootLevelTest struct {
 	taskID   uint64
 }
 
+// FindAllRootLevelTests parses the test file and extracts the name,
+// test code and task id for each top level test (parent test) in the file.
 func FindAllRootLevelTests(fileName string) []rootLevelTest {
 	defer handleASTPanic()
-	// Create a map from test name to data for the test for easy retrieval later on.
 	tests := []rootLevelTest{}
 	fset := token.NewFileSet()
 	ppc := parser.ParseComments

--- a/testrunner/execute.go
+++ b/testrunner/execute.go
@@ -84,7 +84,7 @@ func getStructure(lines bytes.Buffer, input_dir string, ver int, taskIDsEnabled 
 		}
 	}()
 
-	tests, err := processTestResults(lines, input_dir)
+	tests, err := processTestResults(lines, input_dir, taskIDsEnabled)
 	if err != nil {
 		report.Status = statErr
 		report.Message = err.Error()
@@ -117,7 +117,7 @@ func getStructure(lines bytes.Buffer, input_dir string, ver int, taskIDsEnabled 
 	return report
 }
 
-func processTestResults(lines bytes.Buffer, input_dir string) ([]testResult, error) {
+func processTestResults(lines bytes.Buffer, input_dir string, taskIDsEnabled bool) ([]testResult, error) {
 	var (
 		results         = []testResult{}
 		resultIdxByName = make(map[string]int)
@@ -211,7 +211,11 @@ func processTestResults(lines bytes.Buffer, input_dir string) ([]testResult, err
 		return nil, errors.New(pkgLevelMsg)
 	}
 
-	results = addNonExecutedTests(rootLevelTests, results)
+	if taskIDsEnabled {
+		// We only need this for the V3 UI with task ids.
+		// It causes issues for some practice exercises.
+		results = addNonExecutedTests(rootLevelTests, results)
+	}
 
 	return results, nil
 }

--- a/testrunner/execute.go
+++ b/testrunner/execute.go
@@ -216,22 +216,33 @@ func processTestResults(lines bytes.Buffer, input_dir string) ([]testResult, err
 	return results, nil
 }
 
+// addNonExecutedTests adds tests to the result set that were not executed.
+// They are added with status "error" and special message (this is common in other tracks as well).
+// The function makes sure that the result for non-executed test is inserted in the correct position.
 func addNonExecutedTests(rootLevelTests []rootLevelTest, results []testResult) []testResult {
 	insertResultAfterIdx := -1
 	for parentIdx, parentTest := range rootLevelTests {
 		parentFound := false
+
+		// For the given parent test, check whether the result set already contains
+		// test results for it.
 		for resultIdx := range results {
 			parentName, _ := splitTestName(results[resultIdx].Name)
 			if rootLevelTests[parentIdx].name == parentName {
 				insertResultAfterIdx = resultIdx
 				parentFound = true
+				// No "continue" here, we need to find the index of the last (sub)test result
+				// that belongs to a given parent test name.
 			}
 		}
 
+		// If we found test results for the parent test name,
+		// there is nothing to do.
 		if parentFound {
 			continue
 		}
 
+		// If not, we insert the new test result for the test that was not executed.
 		newResult := testResult{
 			Name:     parentTest.name,
 			Status:   statErr,


### PR DESCRIPTION
Adding non-executed tests to the test results caused issues for some practice exercises: https://forum.exercism.org/t/go-track-series-exercise-problem/4503

This changes fixes this by only adding non-exectued tests to the results if the task ids (v3 UI) were enabled.

The PR also contains some function comments that I forgot to commit with my last PR.