### PR TITLE
Support extracting code when initializing test data without field name

### DIFF
--- a/testrunner/extract_test.go
+++ b/testrunner/extract_test.go
@@ -104,6 +104,26 @@ func TestExtractTestCode(t *testing.T) {
 
 }`,
 		}, {
+			name:     "working simple subtest with no field name in test data variable",
+			testName: "TestSimpleSubtest_NoFieldName/parse_ace",
+			testFile: tf,
+			code: `func TestSimpleSubtest_NoFieldName(t *testing.T) {
+	tt := struct {
+		name string
+		card string
+		want int
+	}{
+		"parse ace",
+		"ace",
+		11,
+	}
+	
+	if got := ParseCard(tt.card); got != tt.want {
+		t.Errorf("ParseCard(%s) = %d, want %d", tt.card, got, tt.want)
+	}
+
+}`,
+		}, {
 			name:     "working subtest",
 			testName: "TestParseCard/parse_jack",
 			testFile: tf,

--- a/testrunner/testdata/concept/conditionals/conditionals_test.go
+++ b/testrunner/testdata/concept/conditionals/conditionals_test.go
@@ -32,6 +32,27 @@ func TestSimpleSubtest(t *testing.T) {
 	}
 }
 
+func TestSimpleSubtest_NoFieldName(t *testing.T) {
+	myTests := []struct {
+		name string
+		card string
+		want int
+	}{
+		{
+			"parse ace",
+			"ace",
+			11,
+		},
+	}
+	for _, tt := range myTests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ParseCard(tt.card); got != tt.want {
+				t.Errorf("ParseCard(%s) = %d, want %d", tt.card, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestParseCard(t *testing.T) {
 	tests := []struct {
 		name string

--- a/testrunner/testdata/concept/conditionals/conditionals_test.go
+++ b/testrunner/testdata/concept/conditionals/conditionals_test.go
@@ -43,6 +43,11 @@ func TestSimpleSubtest_NoFieldName(t *testing.T) {
 			"ace",
 			11,
 		},
+		{
+			"parse two",
+			"two",
+			2,
+		},
 	}
 	for _, tt := range myTests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This commit only supports anonymous struct type.
To fully support for named struct type requires a lot of changes in the source code.

Fixes #78