### PR TITLE
Read the complete test file when looking for testcase definitions

### DIFF
--- a/testrunner/ast.go
+++ b/testrunner/ast.go
@@ -12,6 +12,7 @@ import (
 	"go/token"
 	"go/types"
 	"log"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -374,12 +375,24 @@ func processRange(metadata *subTData, rastmt *ast.RangeStmt) bool {
 // resolveTestData resolves test data variable declared in cases_test.go (if exists)
 // and returns type information for identifier resolution
 func resolveTestData(fset *token.FileSet, f *ast.File, file string) *types.Info {
-	filedata := filepath.Join(filepath.Dir(file), "cases_test.go")
-	fdata, _ := parser.ParseFile(fset, filedata, nil, parser.ParseComments)
+	filepaths := []string{file}
+	// Add cases_test.go if it exists.
+	dataFile := filepath.Join(filepath.Dir(file), "cases_test.go")
+	if _, err := os.Stat(dataFile); err == nil {
+		filepaths = append(filepaths, dataFile)
+	}
 
-	// Prepare files for type checking
 	files := []*ast.File{f}
-	if fdata != nil {
+	for _, file := range filepaths {
+		fdata, err := parser.ParseFile(fset, file, nil, parser.ParseComments)
+		if err != nil {
+			log.Printf("parser.ParseFile(%q) failed: %v", file, err)
+			return nil
+		}
+		if fdata == nil {
+			log.Printf("parser.ParseFile(%q) returned nil", file)
+			return nil
+		}
 		files = append(files, fdata)
 	}
 


### PR DESCRIPTION
When forming the "test code", we extract the test function. We then look for a `range` statement in the test function. If found, we look through variable definitions to find the test table. We use the current test name to find the test table by comparing the test name (string) to the strings within each test case. If we find a match, we replace the `for _, tc := range testCases { <test code> }` with a simpler, more explicit, `tc := testCase{...}; <test code>`.

Prior to this PR, the variable definitions are set by parsing (1) the extracted test function and (2) the `cases_test.go` if present. That skips any test definitions in the test file that are declared outside the test function itself.

This PR adds the test file to the list of what is parsed to get the variable definitions.