### PR TITLE
Clean up the Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 FROM golang:1.26.1-alpine3.23
 
-# Add addtional packages needed for the race detector to work
-RUN apk add --update build-base make
-
 # Add a non-root user to run our code as
 RUN adduser --disabled-password appuser
 
@@ -21,14 +18,11 @@ RUN go telemetry off
 # and command packages so future compilations are faster
 RUN go build std cmd
 
-# Install external packages
-WORKDIR /opt/test-runner/external-packages
-RUN go mod download
 # Populate the build cache with the external packages
-RUN go build ./...
+RUN cd /opt/test-runner/external-packages && go mod download && go build ./...
 
 # Build the test runner
-WORKDIR /opt/test-runner
-RUN go build -o /opt/test-runner/bin/test-runner /opt/test-runner
+RUN cd /opt/test-runner && go build -o /opt/test-runner/bin/test-runner /opt/test-runner
 
+WORKDIR /opt/test-runner
 ENTRYPOINT ["sh", "/opt/test-runner/bin/run.sh"]


### PR DESCRIPTION
* Drop packages `build-base make` for ~250MB savings; the test runner doesn't do race detection.
* Combine RUN commands for fewer layers.

Old size: 1164MB
New size:  886MB